### PR TITLE
version compatible with cwp 1.1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,7 @@
     }],
     "require": {
         "silverstripe/framework": "~3.1",
-        "silverstripe/cms": "~3.1",
-        "silverstripe-australia/gridfieldextensions": "~1.0.0"
+        "silverstripe/cms": "~3.1"
     },
     "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "silverstripe/framework": "~3.1",
         "silverstripe/cms": "~3.1",
-	"silverstripe-australia/gridfieldextensions": "1.1.0"
+        "silverstripe-australia/gridfieldextensions": "^1.1.0"
     },
     "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     }],
     "require": {
         "silverstripe/framework": "~3.1",
-        "silverstripe/cms": "~3.1"
+        "silverstripe/cms": "~3.1",
+	"silverstripe-australia/gridfieldextensions": "1.1.0"
     },
     "minimum-stability": "dev"
 }


### PR DESCRIPTION
removed gridfield from dependencies to stop clash in versions for cwp clients using cwp basic recipe > 1.1.1