### PR TITLE
Fixed issue with folder path not being stored with document

### DIFF
--- a/code/model/DMSDocument.php
+++ b/code/model/DMSDocument.php
@@ -744,7 +744,7 @@ class DMSDocument extends DataObject implements DMSDocumentInterface {
 
 		//write the filename of the stored document
 		$this->Filename = $toFilename;
-		$this->Folder = $toFolder;
+		$this->Folder = strval($toFolder);
 
 		$extension = pathinfo($this->Filename, PATHINFO_EXTENSION);
 


### PR DESCRIPTION
Fixed an issues where the Folder field not being set on the DMSDocument model. Value must be set as a string before being saved to the database.